### PR TITLE
Add apostrophe to Sainsbury's name and tidy up DROP TABLE

### DIFF
--- a/src/model/database/db_build.sql
+++ b/src/model/database/db_build.sql
@@ -76,7 +76,7 @@ VALUES
 INSERT INTO supermarkets
     (name)
 VALUES
-    ('Sainsburys'),
+    ('Sainsbury''s'),
     ('Tesco'),
     ('Lidl'),
     ('Aldi'),

--- a/src/model/database/db_build.sql
+++ b/src/model/database/db_build.sql
@@ -1,18 +1,6 @@
 BEGIN;
-    DROP TABLE IF EXISTS products
+    DROP TABLE IF EXISTS products, categories, supermarkets, origins, flags, entries
     CASCADE;
-DROP TABLE IF EXISTS categories
-CASCADE;
-DROP TABLE IF EXISTS supermarkets
-CASCADE;
-DROP TABLE IF EXISTS origins
-CASCADE;
-DROP TABLE IF EXISTS flags
-CASCADE;
-DROP TABLE IF EXISTS entries
-CASCADE;
-
-
 
 CREATE TABLE categories
 (


### PR DESCRIPTION
Added apostrophe in build sql file, so 
`npm run db_init` is required to rebuild databases
tidy up DROP table. Closes #85 